### PR TITLE
Removed /generate/ from endpoint

### DIFF
--- a/devRantBanner/Controllers/BannerController.cs
+++ b/devRantBanner/Controllers/BannerController.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 
 namespace devBanner.Controllers
 {
-    [Route("generate/[controller]")]
+    [Route("[controller]")]
     public class BannerController : Controller
     {
         private readonly ILogger _logger;

--- a/devRantBanner/Properties/launchSettings.json
+++ b/devRantBanner/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     "IIS Express": {
         "commandName": "IISExpress",
         "launchBrowser": true,
-        "launchUrl": "generate/banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text",
+        "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text",
         "environmentVariables": {
             "ASPNETCORE_ENVIRONMENT": "Development"
         }
@@ -19,7 +19,7 @@
     "devRantBanner": {
         "commandName": "Project",
         "launchBrowser": true,
-        "launchUrl": "generate/banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text",
+        "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text",
         "environmentVariables": {
             "ASPNETCORE_ENVIRONMENT": "Development"
         },


### PR DESCRIPTION
Since the whole api was moved to the `generate.` subdomain leaving `/generate/` in the endpoint seems redundant, therefore it was removed.