### PR TITLE
Resolve #12 - Dynamic foreground color

### DIFF
--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -107,15 +107,16 @@ namespace devBanner.Logic
                 var devrantTargetX = banner.Width - 108;
                 var devrantTargetY = banner.Height - 4 - fontSizeDevrant;
                 var devrantTarget = new Point(devrantTargetX, devrantTargetY);
-
+                
+                var backgroundColor = Rgba32.FromHex(profile.Avatar.Background);
                 // Draw background
-                banner.SetBGColor(Rgba32.FromHex(profile.Avatar.Background));
+                banner.SetBGColor(backgroundColor);
 
                 // Draw avatar
                 banner.DrawImage(avatarImage, avatarSize, avatarTarget);
 
                 // Draw username
-                banner.DrawText(profile.Username, fontUsername, Rgba32.White, usernameTarget, verticalAlignment: VerticalAlignment.Top);
+                banner.DrawText(profile.Username, fontUsername, GetForegroundColor(backgroundColor), usernameTarget, verticalAlignment: VerticalAlignment.Top);
 
                 // Scale font size to subtext
                 fontSubtext = fontSubtext.ScaleToText(subtext, new SizeF(subTextWidth, subTextHeight), options.MaxSubtextWidth);
@@ -124,10 +125,10 @@ namespace devBanner.Logic
                 subtext = subtext.AddWrap(fontSubtext, options.MaxSubtextWidth, options.MaxSubtextWraps);
 
                 // Draw subtext
-                banner.DrawText(subtext, fontSubtext, Rgba32.White, subtextTarget, verticalAlignment: VerticalAlignment.Top);
+                banner.DrawText(subtext, fontSubtext, GetForegroundColor(backgroundColor), subtextTarget, verticalAlignment: VerticalAlignment.Top);
 
                 // Draw devrant text
-                banner.DrawText("devrant.com", fontDevrant, Rgba32.White, devrantTarget, HorizontalAlignment.Left, VerticalAlignment.Top);
+                banner.DrawText("devrant.com", fontDevrant, GetForegroundColor(backgroundColor), devrantTarget, HorizontalAlignment.Left, VerticalAlignment.Top);
 
                 banner.Save(outputFile, new PngEncoder());
             }
@@ -135,18 +136,16 @@ namespace devBanner.Logic
             return outputFile;
         }
 
-        //Based on https://stackoverflow.com/questions/1855884/determine-font-color-based-on-background-color. Which itself is based on http://juicystudio.com/article/luminositycontrastratioalgorithm.php
         /// <summary>
-        /// Returns a foreground color based on a background color. 
+        /// Returns a foreground color based on the luminance of the background color. 
         /// </summary>
-        /// <param name="backgroundColor"></param>
-        /// <returns></returns>
+        /// <returns>Black color if the background is bright, white if the background is dark</returns>
         private static Rgba32 GetForegroundColor(Rgba32 backgroundColor)
         {
-            // Calculating the perceptive luminance - human eye favors green color... 
+            // Calculating the perceptive luminance - human eye favors green color... Based on http://juicystudio.com/article/luminositycontrastratioalgorithm.php
             double perceptiveLuminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
 
-            if (perceptiveLuminance > 0.65) //May need to be adjusted. A lower value will trigger black font faster.
+            if (perceptiveLuminance > 0.70) //May need to be adjusted. A lower value will trigger black font faster.
             {
                 return Rgba32.Black; // bright colors - black font
             }

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -145,7 +145,7 @@ namespace devBanner.Logic
             // Calculating the perceptive luminance - human eye favors green color... Based on http://juicystudio.com/article/luminositycontrastratioalgorithm.php
             double perceptiveLuminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
 
-            if (perceptiveLuminance > 0.70) //May need to be adjusted. A lower value will trigger black font faster.
+            if (perceptiveLuminance > 0.65) //May need to be adjusted. A lower value will trigger black font faster.
             {
                 return Rgba32.Black; // bright colors - black font
             }

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -147,13 +147,13 @@ namespace devBanner.Logic
             // Calculating the perceptive luminance - human eye favors green color... Based on http://juicystudio.com/article/luminositycontrastratioalgorithm.php
             double perceptiveLuminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
 
-            if (perceptiveLuminance > 0.7) //May need to be adjusted. A lower value will trigger black font faster.
+            if (perceptiveLuminance > 0.7) // A lower value will trigger black font faster. (0.65 will trigger black font in light blue bg as well)
             {
-                return Rgba32.Black; // bright colors - black font
+                return Rgba32.Black; // bright colors --> black font
             }
             else
             {
-                return Rgba32.White; // dark colors - white font
+                return Rgba32.White; // dark colors --> white font
             }
 
         }

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -147,7 +147,7 @@ namespace devBanner.Logic
             // Calculating the perceptive luminance - human eye favors green color... Based on http://juicystudio.com/article/luminositycontrastratioalgorithm.php
             double perceptiveLuminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
 
-            if (perceptiveLuminance > 0.65) //May need to be adjusted. A lower value will trigger black font faster.
+            if (perceptiveLuminance > 0.7) //May need to be adjusted. A lower value will trigger black font faster.
             {
                 return Rgba32.Black; // bright colors - black font
             }

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -109,6 +109,8 @@ namespace devBanner.Logic
                 var devrantTarget = new Point(devrantTargetX, devrantTargetY);
                 
                 var backgroundColor = Rgba32.FromHex(profile.Avatar.Background);
+                var foregroundColor = GetForegroundColor(backgroundColor);
+                
                 // Draw background
                 banner.SetBGColor(backgroundColor);
 
@@ -116,7 +118,7 @@ namespace devBanner.Logic
                 banner.DrawImage(avatarImage, avatarSize, avatarTarget);
 
                 // Draw username
-                banner.DrawText(profile.Username, fontUsername, GetForegroundColor(backgroundColor), usernameTarget, verticalAlignment: VerticalAlignment.Top);
+                banner.DrawText(profile.Username, fontUsername, foregroundColor, usernameTarget, verticalAlignment: VerticalAlignment.Top);
 
                 // Scale font size to subtext
                 fontSubtext = fontSubtext.ScaleToText(subtext, new SizeF(subTextWidth, subTextHeight), options.MaxSubtextWidth);
@@ -125,10 +127,10 @@ namespace devBanner.Logic
                 subtext = subtext.AddWrap(fontSubtext, options.MaxSubtextWidth, options.MaxSubtextWraps);
 
                 // Draw subtext
-                banner.DrawText(subtext, fontSubtext, GetForegroundColor(backgroundColor), subtextTarget, verticalAlignment: VerticalAlignment.Top);
+                banner.DrawText(subtext, fontSubtext, foregroundColor, subtextTarget, verticalAlignment: VerticalAlignment.Top);
 
                 // Draw devrant text
-                banner.DrawText("devrant.com", fontDevrant, GetForegroundColor(backgroundColor), devrantTarget, HorizontalAlignment.Left, VerticalAlignment.Top);
+                banner.DrawText("devrant.com", fontDevrant, foregroundColor, devrantTarget, HorizontalAlignment.Left, VerticalAlignment.Top);
 
                 banner.Save(outputFile, new PngEncoder());
             }

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -134,5 +134,27 @@ namespace devBanner.Logic
 
             return outputFile;
         }
+
+        //Based on https://stackoverflow.com/questions/1855884/determine-font-color-based-on-background-color. Which itself is based on http://juicystudio.com/article/luminositycontrastratioalgorithm.php
+        /// <summary>
+        /// Returns a foreground color based on a background color. 
+        /// </summary>
+        /// <param name="backgroundColor"></param>
+        /// <returns></returns>
+        private static Rgba32 GetForegroundColor(Rgba32 backgroundColor)
+        {
+            // Calculating the perceptive luminance - human eye favors green color... 
+            double perceptiveLuminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
+
+            if (perceptiveLuminance > 0.65) //May need to be adjusted. A lower value will trigger black font faster.
+            {
+                return Rgba32.Black; // bright colors - black font
+            }
+            else
+            {
+                return Rgba32.White; // dark colors - white font
+            }
+
+        }
     }
 }


### PR DESCRIPTION
This is a solution for issue #12. 

It determines which color to use based on the perceptive luminance of the background color. In its current state, the method will return a black color for light blue and yellow, if the threshold (line 148) is increased to 0.7, black color will only be triggered for yellow.

@cozyplanes I saw you felt it is unnecessary. I feel black on yellow looks better than white on yellow. Not sure for light blue though