### PR TITLE
Partially fixes #10 Custom height and width

### DIFF
--- a/devRantBanner/Controllers/BannerController.cs
+++ b/devRantBanner/Controllers/BannerController.cs
@@ -59,14 +59,7 @@ namespace devBanner.Controllers
 
             try
             {
-                if (width < 16)
-                {
-                    banner = await Banner.GenerateAsync(_bannerOptions, userProfile, text);
-                }
-                else
-                {
-                    banner = await Banner.GenerateAsync(_bannerOptions, userProfile, text, width,  (int)(width / _bannerOptions.WidthToHeightRatio));
-                }
+                banner = await Banner.GenerateAsync(_bannerOptions, userProfile, text, width, (int)(width / _bannerOptions.WidthToHeightRatio));
             }
             catch (AvatarNotFoundException ex)
             {

--- a/devRantBanner/Controllers/BannerController.cs
+++ b/devRantBanner/Controllers/BannerController.cs
@@ -27,7 +27,7 @@ namespace devBanner.Controllers
         // GET/POST banner/get
         [HttpGet]
         [HttpPost]
-        public async Task<IActionResult> Get(string username, string subtext)
+        public async Task<IActionResult> Get(string username, string subtext, int width)
         {
             var client = DevRantClient.Create(new HttpClient());
 
@@ -59,7 +59,14 @@ namespace devBanner.Controllers
 
             try
             {
-                banner = await Banner.GenerateAsync(_bannerOptions, userProfile, text);
+                if (width < 16)
+                {
+                    banner = await Banner.GenerateAsync(_bannerOptions, userProfile, text);
+                }
+                else
+                {
+                    banner = await Banner.GenerateAsync(_bannerOptions, userProfile, text, width,  (int)(width / _bannerOptions.WidthToHeightRatio));
+                }
             }
             catch (AvatarNotFoundException ex)
             {

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -92,9 +92,7 @@ namespace devBanner.Logic
 
                 var fontSizeUsername = (int)(width * 0.08);
                 var fontSizeSubtext = (int)(width * 0.04);
-                var fontSizeDevrant = (int)(width * 0.02);
-
-                
+                var fontSizeDevrant = (int)(width * 0.02);       
 
                 var fontUsername = fontCollection.CreateFont("Comfortaa", fontSizeUsername, FontStyle.Bold);
                 var fontSubtext = fontCollection.CreateFont("Comfortaa", fontSizeSubtext, FontStyle.Regular);
@@ -135,7 +133,7 @@ namespace devBanner.Logic
                 banner.DrawText(profile.Username, fontUsername, foregroundColor, usernameTarget, verticalAlignment: VerticalAlignment.Top);
 
                 // Scale font size to subtext
-                fontSubtext = fontSubtext.ScaleToText(subtext, new SizeF(subTextWidth, subTextHeight), options.MaxSubtextWidth);
+                fontSubtext = fontSubtext.ScaleToText(subtext, new SizeF(subTextWidth, subTextHeight), subTextWidth);
 
                 // Add subtext word wrapping
                 subtext = subtext.AddWrap(fontSubtext, subTextWidth, options.MaxSubtextWraps);

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -17,7 +17,7 @@ namespace devBanner.Logic
     {
         private const string DevrantAvatarBaseURL = "https://avatars.devrant.com";
 
-        public static async Task<string> GenerateAsync(BannerOptions options, Profile profile, string subtext)
+        public static async Task<string> GenerateAsync(BannerOptions options, Profile profile, string subtext, int width = 800, int height = 192)
         {
             if (profile == null)
             {
@@ -73,7 +73,7 @@ namespace devBanner.Logic
             }
 
             using (var avatarImage = Image.Load(data))
-            using (var banner = new Image<Rgba32>(800, 192))
+            using (var banner = new Image<Rgba32>(width, height))
             {
                 var fontCollection = new FontCollection();
                 fontCollection.Install("fonts/Comfortaa-Regular.ttf");

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -24,17 +24,17 @@ namespace devBanner.Logic
                 throw new ArgumentNullException(nameof(profile));
             }
 
-            if (width < 128)
+            if (width < options.MinWidth)
             {
-                width = 800;
-                height = 192;
+                width = options.DefaultWidth;                
             }
 
-            if (width > 2048)
+            if (width > options.MaxWidth)
             {
-                width = 2048;
-                height = (int)(width / options.WidthToHeightRatio);
+                width = options.MaxWidth;
             }
+
+            height = (int)(width / options.WidthToHeightRatio);
 
             // Avatar base url + avatar meta = rendered avatar url
             var avatarURL = $"{DevrantAvatarBaseURL}/{profile.Avatar.Image}";

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -24,7 +24,7 @@ namespace devBanner.Logic
                 throw new ArgumentNullException(nameof(profile));
             }
 
-            if (width < 64)
+            if (width < 128)
             {
                 width = 800;
                 height = 192;
@@ -102,7 +102,7 @@ namespace devBanner.Logic
                 var avatarWidth = avatarHeight;
                 var avatarSize = new Size(avatarWidth, avatarHeight);
 
-                var avatarTargetX = 15;
+                var avatarTargetX = (int)(width * 0.01875);
                 var avatarTargetY = 0;
                 var avatarTarget = new Point(avatarTargetX, avatarTargetY);
 
@@ -113,7 +113,7 @@ namespace devBanner.Logic
                 var subtextTargetX = usernameTarget.X;
                 var subtextTargetY = usernameTarget.Y + fontSizeUsername;
                 var subtextTarget = new PointF(subtextTargetX, subtextTargetY + (fontSizeSubtext / 2f));
-                var subTextWidth = banner.Width - subtextTargetX - 15;
+                var subTextWidth = banner.Width - subtextTargetX - (int)(width * 0.01875);
                 var subTextHeight = fontSizeSubtext;
 
                 var devrantTargetX = banner.Width - (int)(width * 0.130);

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -24,17 +24,9 @@ namespace devBanner.Logic
                 throw new ArgumentNullException(nameof(profile));
             }
 
-            if (width < options.MinWidth)
-            {
-                width = options.DefaultWidth;                
-            }
+            var checkedWidth = CheckWidth(options, width);
 
-            if (width > options.MaxWidth)
-            {
-                width = options.MaxWidth;
-            }
-
-            height = (int)(width / options.WidthToHeightRatio);
+            height = (int)(checkedWidth / options.WidthToHeightRatio);
 
             // Avatar base url + avatar meta = rendered avatar url
             var avatarURL = $"{DevrantAvatarBaseURL}/{profile.Avatar.Image}";
@@ -85,14 +77,14 @@ namespace devBanner.Logic
             }
 
             using (var avatarImage = Image.Load(data))
-            using (var banner = new Image<Rgba32>(width, height))
+            using (var banner = new Image<Rgba32>(checkedWidth, height))
             {
                 var fontCollection = new FontCollection();
                 fontCollection.Install("fonts/Comfortaa-Regular.ttf");
 
-                var fontSizeUsername = (int)(width * 0.08);
-                var fontSizeSubtext = (int)(width * 0.04);
-                var fontSizeDevrant = (int)(width * 0.02);       
+                var fontSizeUsername = (int)(checkedWidth * 0.08);
+                var fontSizeSubtext = (int)(checkedWidth * 0.04);
+                var fontSizeDevrant = (int)(checkedWidth * 0.02);
 
                 var fontUsername = fontCollection.CreateFont("Comfortaa", fontSizeUsername, FontStyle.Bold);
                 var fontSubtext = fontCollection.CreateFont("Comfortaa", fontSizeSubtext, FontStyle.Regular);
@@ -102,7 +94,7 @@ namespace devBanner.Logic
                 var avatarWidth = avatarHeight;
                 var avatarSize = new Size(avatarWidth, avatarHeight);
 
-                var avatarTargetX = (int)(width * 0.01875);
+                var avatarTargetX = (int)(checkedWidth * 0.01875);
                 var avatarTargetY = 0;
                 var avatarTarget = new Point(avatarTargetX, avatarTargetY);
 
@@ -113,16 +105,16 @@ namespace devBanner.Logic
                 var subtextTargetX = usernameTarget.X;
                 var subtextTargetY = usernameTarget.Y + fontSizeUsername;
                 var subtextTarget = new PointF(subtextTargetX, subtextTargetY + (fontSizeSubtext / 2f));
-                var subTextWidth = banner.Width - subtextTargetX - (int)(width * 0.01875);
+                var subTextWidth = banner.Width - subtextTargetX - (int)(checkedWidth * 0.01875);
                 var subTextHeight = fontSizeSubtext;
 
-                var devrantTargetX = banner.Width - (int)(width * 0.130);
-                var devrantTargetY = banner.Height - (int)(width * 0.03);
+                var devrantTargetX = banner.Width - (int)(checkedWidth * 0.130);
+                var devrantTargetY = banner.Height - (int)(checkedWidth * 0.03);
                 var devrantTarget = new Point(devrantTargetX, devrantTargetY);
-                
+
                 var backgroundColor = Rgba32.FromHex(profile.Avatar.Background);
                 var foregroundColor = GetForegroundColor(backgroundColor);
-                
+
                 // Draw background
                 banner.SetBGColor(backgroundColor);
 
@@ -148,6 +140,33 @@ namespace devBanner.Logic
             }
 
             return outputFile;
+        }
+
+        /// <summary>
+        /// Check width according to the banner options 
+        /// </summary>
+        /// <returns>A width that is consistant with the min, max, and default width defined in the banner options</returns>
+        private static int CheckWidth(BannerOptions options, int width)
+        {
+            var checkedWidth = 0;
+            if (width <= 0)
+            {
+                checkedWidth = options.DefaultWidth;
+            }
+            else if (width < options.MinWidth)
+            {
+                checkedWidth = options.MinWidth;
+            }
+            else if (width > options.MaxWidth)
+            {
+                checkedWidth = options.MaxWidth;
+            }
+            else
+            {
+                checkedWidth = width;
+            }
+
+            return checkedWidth;
         }
 
         /// <summary>

--- a/devRantBanner/Logic/Banner.cs
+++ b/devRantBanner/Logic/Banner.cs
@@ -24,6 +24,18 @@ namespace devBanner.Logic
                 throw new ArgumentNullException(nameof(profile));
             }
 
+            if (width < 64)
+            {
+                width = 800;
+                height = 192;
+            }
+
+            if (width > 2048)
+            {
+                width = 2048;
+                height = (int)(width / options.WidthToHeightRatio);
+            }
+
             // Avatar base url + avatar meta = rendered avatar url
             var avatarURL = $"{DevrantAvatarBaseURL}/{profile.Avatar.Image}";
 
@@ -78,9 +90,11 @@ namespace devBanner.Logic
                 var fontCollection = new FontCollection();
                 fontCollection.Install("fonts/Comfortaa-Regular.ttf");
 
-                var fontSizeUsername = 64;
-                var fontSizeSubtext = fontSizeUsername / 2;
-                var fontSizeDevrant = 16;
+                var fontSizeUsername = (int)(width * 0.08);
+                var fontSizeSubtext = (int)(width * 0.04);
+                var fontSizeDevrant = (int)(width * 0.02);
+
+                
 
                 var fontUsername = fontCollection.CreateFont("Comfortaa", fontSizeUsername, FontStyle.Bold);
                 var fontSubtext = fontCollection.CreateFont("Comfortaa", fontSizeSubtext, FontStyle.Regular);
@@ -104,8 +118,8 @@ namespace devBanner.Logic
                 var subTextWidth = banner.Width - subtextTargetX - 15;
                 var subTextHeight = fontSizeSubtext;
 
-                var devrantTargetX = banner.Width - 108;
-                var devrantTargetY = banner.Height - 4 - fontSizeDevrant;
+                var devrantTargetX = banner.Width - (int)(width * 0.130);
+                var devrantTargetY = banner.Height - (int)(width * 0.03);
                 var devrantTarget = new Point(devrantTargetX, devrantTargetY);
                 
                 var backgroundColor = Rgba32.FromHex(profile.Avatar.Background);
@@ -124,7 +138,7 @@ namespace devBanner.Logic
                 fontSubtext = fontSubtext.ScaleToText(subtext, new SizeF(subTextWidth, subTextHeight), options.MaxSubtextWidth);
 
                 // Add subtext word wrapping
-                subtext = subtext.AddWrap(fontSubtext, options.MaxSubtextWidth, options.MaxSubtextWraps);
+                subtext = subtext.AddWrap(fontSubtext, subTextWidth, options.MaxSubtextWraps);
 
                 // Draw subtext
                 banner.DrawText(subtext, fontSubtext, foregroundColor, subtextTarget, verticalAlignment: VerticalAlignment.Top);

--- a/devRantBanner/Options/BannerOptions.cs
+++ b/devRantBanner/Options/BannerOptions.cs
@@ -12,5 +12,7 @@
 
         // In minutes
         public int MaxCacheAvatarAge { get; set; }
+
+        public float WidthToHeightRatio { get; set; }
     }
 }

--- a/devRantBanner/Options/BannerOptions.cs
+++ b/devRantBanner/Options/BannerOptions.cs
@@ -4,8 +4,6 @@
     {
         public int MaxSubtextLength { get; set; }
 
-        public float MaxSubtextWidth { get; set; }
-
         public int MaxSubtextWraps { get; set; }
 
         public bool CacheAvatars { get; set; }
@@ -14,5 +12,11 @@
         public int MaxCacheAvatarAge { get; set; }
 
         public float WidthToHeightRatio { get; set; }
+
+        public int DefaultWidth { get; set; }
+
+        public int MinWidth { get; set; }
+
+        public int MaxWidth { get; set; }
     }
 }

--- a/devRantBanner/Properties/launchSettings.json
+++ b/devRantBanner/Properties/launchSettings.json
@@ -9,21 +9,21 @@
   },
   "profiles": {
     "IIS Express": {
-        "commandName": "IISExpress",
-        "launchBrowser": true,
-        "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text",
-        "environmentVariables": {
-            "ASPNETCORE_ENVIRONMENT": "Development"
-        }
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text&width=3957",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     },
     "devRantBanner": {
-        "commandName": "Project",
-        "launchBrowser": true,
-        "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text",
-        "environmentVariables": {
-            "ASPNETCORE_ENVIRONMENT": "Development"
-        },
-        "applicationUrl": "http://localhost:62253/"
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:62253/"
     }
   }
 }

--- a/devRantBanner/Properties/launchSettings.json
+++ b/devRantBanner/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text&width=3957",
+      "launchUrl": "banner?username=Kimmax&subtext=This%20is%20a%20wonderful%20text&width=2048",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/devRantBanner/appsettings.json
+++ b/devRantBanner/appsettings.json
@@ -10,6 +10,7 @@
     "MaxSubtextWidth": 380,
     "MaxSubtextWraps": 2,
     "CacheAvatars": true,
-    "MaxCacheAvatarAge": 15
+    "MaxCacheAvatarAge": 15,
+    "WidthToHeightRatio": 4.16
   }
 }

--- a/devRantBanner/appsettings.json
+++ b/devRantBanner/appsettings.json
@@ -7,10 +7,12 @@
   },
   "Banner": {
     "MaxSubtextLength": 200,
-    "MaxSubtextWidth": 380,
     "MaxSubtextWraps": 2,
     "CacheAvatars": true,
     "MaxCacheAvatarAge": 15,
-    "WidthToHeightRatio": 4.16
+    "WidthToHeightRatio": 4.16,
+    "DefaultWidth": 800,
+    "MinWidth": 128,
+    "MaxWidth": 2048
   }
 }


### PR DESCRIPTION
Add custom width. Heigh is constrained to the width.

It should still work with the current front end. 

Text is adjusted automatically according to the width. 

The min, max, default width, and width to height values are configurable.

The `MaxSubtextWidth `has been removed from the options as it made no sense anymore. The max subtext width is now relative to the banner width

The max width is currently limited to 2048 for two reasons:
1) To limit RAM usage. A bigger size could be a problem if there is a heavy load.
2) Bigger font size generate visual artefacts on drown text. I don't know if it is an issue with the ImageSharp library or if it is because we don't use it well.